### PR TITLE
fix vite global.css import

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -120,6 +120,9 @@
       "types": "./dist/lib/utils.d.ts",
       "import": "./dist/lib/utils.mjs",
       "require": "./dist/lib/utils.js"
+    },
+    "./dist/globals.css": {
+      "import": "./dist/globals.css"
     }
   }
 }


### PR DESCRIPTION
when importing "@ferdiunal/refine-shadcn/dist/globals.css" using vite.js, the following error is raised:
```
[vite] Internal server error: Missing "./dist/globals.css" specifier in "@ferdiunal/refine-shadcn" package
```